### PR TITLE
Removed a stray word in the pause error message.

### DIFF
--- a/addons/fpc/character.gd
+++ b/addons/fpc/character.gd
@@ -112,7 +112,7 @@ func check_controls(): # If you add a control, you might want to add a check for
 		push_error("No control mapped for move backward. Please add an input map control. Disabling movement.")
 		immobile = true
 	if !InputMap.has_action(PAUSE):
-		push_error("No control mapped for move pause. Please add an input map control. Disabling pausing.")
+		push_error("No control mapped for pause. Please add an input map control. Disabling pausing.")
 		pausing_enabled = false
 	if !InputMap.has_action(CROUCH):
 		push_error("No control mapped for crouch. Please add an input map control. Disabling crouching.")


### PR DESCRIPTION
Removed the word "move" from the error statement referring to the action PAUSE.

*UNRELATED SIDE NOTE: I read over the whole script multiple times and could find nothing obvious that would cause the crouch, sprint errors. The only thing I found was this misplaced word.*