### PR TITLE
Removed hardcoded lines (causing the sprint and crouch bug) from Character.tscn

### DIFF
--- a/addons/fpc/character.tscn
+++ b/addons/fpc/character.tscn
@@ -360,8 +360,6 @@ HEADBOB_ANIMATION = NodePath("Head/HeadbobAnimation")
 JUMP_ANIMATION = NodePath("Head/JumpAnimation")
 CROUCH_ANIMATION = NodePath("CrouchAnimation")
 COLLISION_MESH = NodePath("Collision")
-CROUCH = "crouch"
-SPRINT = "sprint"
 
 [node name="Mesh" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)


### PR DESCRIPTION
I found two values in the editor that were causing `var CROUCH` and `var SPRINT` to be set to the values of "sprint" and "crouch"

Removing these lines clears up the variable for use with the `String = user specified value` assignment.