### PR TITLE
Update character.gd for base_speed fix

### DIFF
--- a/addons/fpc/character.gd
+++ b/addons/fpc/character.gd
@@ -117,6 +117,7 @@ func _ready():
 	CROUCH_ANIMATION.play("RESET")
 	
 	check_controls()
+	enter_normal_state()
 
 func check_controls(): # If you add a control, you might want to add a check for it here.
 	# The actions are being disabled so the engine doesn't halt the entire project in debug mode


### PR DESCRIPTION
base_speed is assigned to speed before the default is updated to what is set in the export variable causing it to be the incorrect value. Calling enter_normal_state() on ready sets speed to the correct value before the player gains control. From my testing, this has no side effects.

Fixes issue #28.