### PR TITLE
Update debug.gd

### DIFF
--- a/addons/fpc/debug.gd
+++ b/addons/fpc/debug.gd
@@ -15,4 +15,7 @@ func add_property(title : String, value, order : int): # This can either be call
 		target.text = title + ": " + str(value)
 	elif visible:
 		target.text = title + ": " + str(value)
+		var size = $MarginContainer/VBoxContainer.get_child_count()
+		if order > size:
+			order = size
 		$MarginContainer/VBoxContainer.move_child(target, order)


### PR DESCRIPTION
When changing order of debug items or adding custom items you might get error in editor like " debug.gd:21 @ add_property(): Invalid new child index: 5." 

Caused by items being moved by order before there are enough items in debug menu. This is one way to solve that. You will no longer have errors in editor and items will be in right order after first frame.